### PR TITLE
Add support for `eth_brl` book in WebSocket API

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -197,4 +197,6 @@ pub enum Books {
     DaiArs,
     #[strum(serialize = "btc_brl")]
     BtcBrl,
+    #[strum(serialize = "eth_brl")]
+    EthBrl,
 }


### PR DESCRIPTION
`all_books_and_proper_name` test started failing due to the unsupported book in the WebSocket API impl. 