### PR TITLE
Add support for `btc_usdt` book in WebSocket API

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -199,4 +199,6 @@ pub enum Books {
     BtcBrl,
     #[strum(serialize = "eth_brl")]
     EthBrl,
+    #[strum(serialize = "btc_usdt")]
+    BtcUsdt,
 }


### PR DESCRIPTION
`all_books_and_proper_name` test started failing due to the unsupported book in the WebSocket API impl.