### PR TITLE
Bump MSRV: `1.47.0` -> `1.49.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.49.0
           override: true
 
       - name: Run tests
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.49.0
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.49.0
           override: true
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
@@ -66,20 +66,20 @@ jobs:
           args: --all --benches
 
   clippy:
-    name: Clippy (1.47.0)
+    name: Clippy
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.49.0
           components: clippy
           override: true
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
-          name: Clippy (1.47.0)
+          name: Clippy
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0
+          toolchain: 1.49.0
           override: true
 
       # cargo fmt does not build the code, and running it in a fresh clone of


### PR DESCRIPTION
This is to avoid any problems with the `parking_lot` crate. For more information, see [this issue](https://github.com/rust-lang/rust/issues/55002).