### PR TITLE
Update client to reflect some recent changes (documented in changelog)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitsors"
-version = "1.0.10"
+version = "1.1.0"
 license = "MIT"
 readme = "README.md"
 description = "A Rust wrapper for the Bitso API"

--- a/examples/open_orders.rs
+++ b/examples/open_orders.rs
@@ -17,6 +17,6 @@ async fn main() {
     let bitso = Bitso::default()
         .client_credentials_manager(client_credential)
         .build();
-    let result = bitso.get_open_orders(Some("btc_mxn"), None).await;
+    let result = bitso.get_open_orders(Some("btc_mxn"), None, None).await;
     println!("{:?}", result);
 }

--- a/examples/user_trades.rs
+++ b/examples/user_trades.rs
@@ -17,6 +17,8 @@ async fn main() {
     let bitso = Bitso::default()
         .client_credentials_manager(client_credential)
         .build();
-    let result = bitso.get_user_trades("btc_mxn", None, None, None).await;
+    let result = bitso
+        .get_user_trades(Some("btc_mxn"), None, None, None)
+        .await;
     println!("{:?}", result);
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -658,7 +658,8 @@ impl Bitso {
     pub async fn get_open_orders<'a>(
         &self,
         book: Option<&str>,
-        optional_params: Option<OptionalParams<'_>>,
+        currency: Option<&str>,
+        limit: Option<&u8>,
     ) -> Result<JSONResponse<Vec<OpenOrdersPayload>>> {
         let url = String::from("/v3/open_orders");
         let mut params = HashMap::new();
@@ -666,17 +667,11 @@ impl Bitso {
         if let Some(b) = book {
             params.insert("book".to_owned(), b.to_string());
         }
-        // Add generic optional parameters
-        if let Some(op) = optional_params {
-            if let Some(m) = op.marker {
-                params.insert("marker".to_owned(), m.to_string());
-            }
-            if let Some(s) = op.sort {
-                params.insert("sort".to_owned(), s.to_string());
-            }
-            if let Some(l) = op.limit {
-                params.insert("limit".to_owned(), l.to_string());
-            }
+        if let Some(c) = currency {
+            params.insert("currency".to_owned(), c.to_string());
+        }
+        if let Some(l) = limit {
+            params.insert("limit".to_owned(), l.to_string());
         }
         match client_credentials {
             Some(c) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -586,7 +586,6 @@ impl Bitso {
         let mut url = String::from("/v3/user_trades/");
         let mut params = HashMap::new();
         let client_credentials = self.client_credentials_manager.as_ref();
-        // params.insert("book".to_owned(), book.to_string());
         if let Some(b) = book {
             params.insert("book".to_owned(), b.to_string());
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -578,7 +578,7 @@ impl Bitso {
     /// See: <https://bitso.com/api_info#user-trades>
     pub async fn get_user_trades(
         &self,
-        book: &str,
+        book: Option<&str>,
         tid: Option<&str>,
         tids: Option<Vec<&str>>,
         optional_params: Option<OptionalParams<'_>>,
@@ -586,7 +586,10 @@ impl Bitso {
         let mut url = String::from("/v3/user_trades/");
         let mut params = HashMap::new();
         let client_credentials = self.client_credentials_manager.as_ref();
-        params.insert("book".to_owned(), book.to_string());
+        // params.insert("book".to_owned(), book.to_string());
+        if let Some(b) = book {
+            params.insert("book".to_owned(), b.to_string());
+        }
         if let Some(t) = tid {
             url.push_str(t);
             url.push('/');

--- a/src/client.rs
+++ b/src/client.rs
@@ -806,7 +806,7 @@ impl Bitso {
     }
 
     /// Make a request to get lookup orders
-    /// See: <https://bitso.com/api_info#lookup-orders>
+    /// See: <https://bitso.com/api_info#funding-destination>
     pub async fn get_funding_destination(
         &self,
         fund_currency: &str,

--- a/src/model/private.rs
+++ b/src/model/private.rs
@@ -197,6 +197,7 @@ pub struct OrderTradesPayload {
     pub oid: Option<String>,
     pub client_id: Option<String>,
     pub side: Option<String>,
+    pub maker_side: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/tests/test_private_api.rs
+++ b/tests/test_private_api.rs
@@ -644,8 +644,38 @@ async fn test_fundings() {
 /// Test successful request to get user_trades
 #[tokio::test]
 async fn test_user_trades() {
-    let _mock = mock("GET", "/v3/user_trades/")
+    let mut _mock = mock("GET", "/v3/user_trades/")
         .match_query(Matcher::UrlEncoded("book".into(), "btc_mxn".into()))
+        .with_status(200)
+        .with_body(
+            r#"{
+            "success": true,
+            "payload": [{
+                "book": "btc_mxn",
+                "major": "-0.25232073",
+                "created_at": "2016-04-08T17:52:31.000+00:00",
+                "minor": "1013.540958479115",
+                "fees_amount": "-10.237787459385",
+                "fees_currency": "mxn",
+                "price": "4057.45",
+                "tid": 51756,
+                "oid": "g81d3y1ywri0yg8m",
+                "side": "sell",
+                "maker_side": "sell"
+            }]
+        }"#,
+        )
+        .create();
+    let bitso = Bitso::default()
+        .prefix(mockito::server_url().as_str())
+        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
+        .build();
+    let mut result = bitso
+        .get_user_trades(Some("btc_mxn"), None, None, None)
+        .await;
+    assert!(result.is_ok());
+    println!("{:?}", result);
+    _mock = mock("GET", "/v3/user_trades/")
         .with_status(200)
         .with_body(
             r#"{
@@ -678,11 +708,7 @@ async fn test_user_trades() {
         }"#,
         )
         .create();
-    let bitso = Bitso::default()
-        .prefix(mockito::server_url().as_str())
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
-    let result = bitso.get_user_trades("btc_mxn", None, None, None).await;
+    result = bitso.get_user_trades(None, None, None, None).await;
     assert!(result.is_ok());
     println!("{:?}", result);
 }

--- a/tests/test_private_api.rs
+++ b/tests/test_private_api.rs
@@ -823,7 +823,7 @@ async fn test_open_orders() {
                 "oid": "543cr2v32a1h68443",
                 "origin_id": "origin_id1",
                 "side": "buy",
-                "status": "partial-fill",
+                "status": "partially filled",
                 "type": "limit"
             }, {
                 "book": "btc_mxn",
@@ -887,7 +887,7 @@ async fn test_open_orders_optional_params() {
                 "oid": "543cr2v32a1h68443",
                 "origin_id": "origin_id1",
                 "side": "buy",
-                "status": "partial-fill",
+                "status": "partially filled",
                 "type": "limit"
             }, {
                 "book": "btc_mxn",
@@ -955,7 +955,7 @@ async fn test_lookup_orders_with_optional_params() {
                 "price": "5600.00",
                 "oid": "543cr2v32a1h6844",
                 "side": "buy",
-                "status": "partial-fill",
+                "status": "partially filled",
                 "type": "limit"
             }, {
                 "book": "btc_mxn",
@@ -1006,7 +1006,7 @@ async fn test_lookup_orders() {
                 "price": "5600.00",
                 "oid": "543cr2v32a1h6844",
                 "side": "buy",
-                "status": "partial-fill",
+                "status": "partially filled",
                 "type": "limit"
             }]
         }"#,

--- a/tests/test_private_api.rs
+++ b/tests/test_private_api.rs
@@ -803,76 +803,12 @@ async fn test_order_trades_origin_id() {
 /// Test successful request to get open_orders
 #[tokio::test]
 async fn test_open_orders() {
-    let _mock = mock("GET", "/v3/open_orders")
+    let mut _mock = mock("GET", "/v3/open_orders")
         .with_status(200)
-        .match_query(Matcher::AllOf(vec![Matcher::UrlEncoded(
-            "book".into(),
-            "btc_mxn".into(),
-        )]))
-        .with_body(
-            r#"{
-            "success": true,
-            "payload": [{
-                "book": "btc_mxn",
-                "original_amount": "0.01000000",
-                "unfilled_amount": "0.00500000",
-                "original_value": "56.0",
-                "created_at": "2016-04-08T17:52:31.000+00:00",
-                "updated_at": "2016-04-08T17:52:51.000+00:00",
-                "price": "5600.00",
-                "oid": "543cr2v32a1h68443",
-                "origin_id": "origin_id1",
-                "side": "buy",
-                "status": "partially filled",
-                "type": "limit"
-            }, {
-                "book": "btc_mxn",
-                "original_amount": "0.12680000",
-                "unfilled_amount": "0.12680000",
-                "original_value": "507.2",
-                "created_at": "2016-04-08T17:52:31.000+00:00",
-                "updated_at": "2016-04-08T17:52:41.000+00:00",
-                "price": "4000.00",
-                "oid": "qlbga6b600n3xta7",
-                "side": "sell",
-                "status": "open",
-                "type": "limit"
-            }, {
-                "book": "btc_mxn",
-                "original_amount": "1.12560000",
-                "unfilled_amount": "1.12560000",
-                "original_value": "6892.66788",
-                "created_at": "2016-04-08T17:52:31.000+00:00",
-                "updated_at": "2016-04-08T17:52:41.000+00:00",
-                "price": "6123.55",
-                "oid": "d71e3xy2lowndkfm",
-                "side": "sell",
-                "status": "open",
-                "type": "limit"
-            }]
-        }"#,
-        )
-        .create();
-    let bitso = Bitso::default()
-        .prefix(mockito::server_url().as_str())
-        .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
-        .build();
-    let result = bitso.get_open_orders(Some("btc_mxn"), None).await;
-    assert!(result.is_ok());
-    println!("{:?}", result);
-}
-
-/// Test successful request to get open_orders with optional params
-#[tokio::test]
-async fn test_open_orders_optional_params() {
-    let _mock = mock("GET", "/v3/open_orders")
         .match_query(Matcher::AllOf(vec![
             Matcher::UrlEncoded("book".into(), "btc_mxn".into()),
-            Matcher::UrlEncoded("marker".into(), "51755".into()),
-            Matcher::UrlEncoded("sort".into(), "asc".into()),
-            Matcher::UrlEncoded("limit".into(), "1".into()),
+            Matcher::UrlEncoded("currency".into(), "mxn".into()),
         ]))
-        .with_status(200)
         .with_body(
             r#"{
             "success": true,
@@ -921,16 +857,40 @@ async fn test_open_orders_optional_params() {
         .prefix(mockito::server_url().as_str())
         .client_credentials_manager(CLIENT_CREDENTIAL.lock().unwrap().clone())
         .build();
-    let optional_params = OptionalParams {
-        marker: Some(&51755),
-        sort: Some("asc"),
-        limit: Some(&1),
-    };
-    let result = bitso
-        .get_open_orders(Some("btc_mxn"), Some(optional_params))
+    let mut result = bitso
+        .get_open_orders(Some("btc_mxn"), Some("mxn"), None)
         .await;
-    println!("{:?}", result);
     assert!(result.is_ok());
+    println!("{:?}", result);
+    _mock = mock("GET", "/v3/open_orders")
+        .with_status(200)
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("book".into(), "btc_mxn".into()),
+            Matcher::UrlEncoded("limit".into(), "1".into()),
+        ]))
+        .with_body(
+            r#"{
+            "success": true,
+            "payload": [{
+                "book": "btc_mxn",
+                "original_amount": "0.01000000",
+                "unfilled_amount": "0.00500000",
+                "original_value": "56.0",
+                "created_at": "2016-04-08T17:52:31.000+00:00",
+                "updated_at": "2016-04-08T17:52:51.000+00:00",
+                "price": "5600.00",
+                "oid": "543cr2v32a1h68443",
+                "origin_id": "origin_id1",
+                "side": "buy",
+                "status": "partially filled",
+                "type": "limit"
+            }]
+        }"#,
+        )
+        .create();
+    result = bitso.get_open_orders(Some("btc_mxn"), None, Some(&1)).await;
+    assert!(result.is_ok());
+    println!("{:?}", result);
 }
 
 /// Test successful request to get lookup_orders with optional params

--- a/tests/test_private_api.rs
+++ b/tests/test_private_api.rs
@@ -661,7 +661,7 @@ async fn test_user_trades() {
                 "tid": 51756,
                 "oid": "g81d3y1ywri0yg8m",
                 "side": "sell",
-                "make_side": "sell"
+                "maker_side": "sell"
             }, {
                 "book": "eth_mxn",
                 "major": "4.86859395",
@@ -673,7 +673,7 @@ async fn test_user_trades() {
                 "tid": 51757,
                 "oid": "19vaqiv72drbphig",
                 "side": "buy",
-                "make_side": "sell"
+                "maker_side": "sell"
             }]
         }"#,
         )
@@ -707,7 +707,7 @@ async fn test_order_trades() {
                     "oid": "Jvqrschkgdkc1go3",
                     "origin_id": "origin_id1",
                     "side": "sell",
-                    "make_side": "sell"
+                    "maker_side": "sell"
                 },
                 {
                     "book": "btc_mxn",
@@ -721,7 +721,7 @@ async fn test_order_trades() {
                     "oid": "Jvqrschkgdkc1go3",
                     "origin_id": "origin_id1",
                     "side": "sell",
-                    "make_side": "sell"
+                    "maker_side": "sell"
                 }
             ]
         }"#,
@@ -760,7 +760,7 @@ async fn test_order_trades_origin_id() {
                     "oid": "Jvqrschkgdkc1go3",
                     "origin_id": "origin_id1",
                     "side": "sell",
-                    "make_side": "sell"
+                    "maker_side": "sell"
                 }]
         }"#,
         )


### PR DESCRIPTION
This PR includes recent changes documented in the [changelog](https://bitso.com/api_info/#changelog). Specifically:

* Fix `order_trades` endpoint to include the `maker_side` field.
* Make `book` and optional parameter in the `user_trade` endpoint.
* Change `partial-fill` to `partially filled` in the `open orders` and `lookup orders` tests.
* Fix parameters in the `open_orders` endpoint, so as to recieve `book`, `currency` and `limit`.

