### PR TITLE
Update `MSRV`: `1.49.0` -> `1.56.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0
+          toolchain: 1.56.1
           override: true
 
       - name: Run tests
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0
+          toolchain: 1.56.1
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0
+          toolchain: 1.56.1
           override: true
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0
+          toolchain: 1.56.1
           components: clippy
           override: true
       - name: Run clippy
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0
+          toolchain: 1.56.1
           override: true
 
       # cargo fmt does not build the code, and running it in a fresh clone of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitsors"
-version = "1.1.9"
+version = "1.1.10"
 license = "MIT"
 readme = "README.md"
 description = "A Rust wrapper for the Bitso API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ description = "A Rust wrapper for the Bitso API"
 homepage = "https://github.com/bitsoex/bitso-rs/"
 keywords = ["bitso", "api", "cryptocurrencies"]
 authors = ["arturo <arturomf94@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Crates.io](https://img.shields.io/crates/v/bitsors.svg)](https://crates.io/crates/bitsors)
 [![Docs](https://docs.rs/bitsors/badge.svg)](https://docs.rs/bitsors)
 [![CI checks](https://github.com/bitsoex/bitso-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/bitsoex/bitso-rs/actions/workflows/ci.yml)
+[![rustc](https://img.shields.io/badge/rust-1.56%2B-orange.svg)](https://img.shields.io/badge/rust-1.56%2B-orange.svg)
 
 # bitsors
 A Rust wrapper for the [Bitso API](https://bitso.com/api_info/), with support for the [public](https://bitso.com/api_info#public-rest-api) and [private](https://bitso.com/api_info#private-rest-api) API endpoints, plus the [WebSocket API](https://bitso.com/api_info#websocket-api).
@@ -23,3 +24,6 @@ cargo clippy --all-features --all-targets -- -D warnings
 
 You can find lots of examples under the `examples/` folder!
 
+## MSRV
+
+`1.56.1`


### PR DESCRIPTION
This accounts for the latest release of the `hashbrown` crate on [version 0.12.1](https://crates.io/crates/hashbrown/0.12.1).